### PR TITLE
Bump equator dependency to 0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 keywords = ["vec", "allocation", "box", "slice", "alignment"]
 
 [dependencies]
-equator = "0.2.0"
+equator = "0.4.1"
 serde = { version = "1.0", optional = true, default-features = false }
 
 [features]


### PR DESCRIPTION
Don’t depend on the old 0.2.x series. This doesn’t appear to require any source changes; `cargo test` still passes.