### PR TITLE
Fix deserialization under limits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ keywords = ["vec", "allocation", "box", "slice", "alignment"]
 equator = "0.4.1"
 serde = { version = "1.0", optional = true, default-features = false }
 
+[dev-dependencies]
+bincode = { version = "1" }
+
 [features]
 default = ["std"]
 std = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -966,7 +966,6 @@ mod serde {
         }
     }
 
-    #[cfg(any(feature = "std"))]
     pub fn cautious<Element>(hint: Option<usize>) -> usize {
         use core::{cmp, mem};
 
@@ -1382,6 +1381,7 @@ mod serde_tests {
 
     #[test]
     fn can_limit_deserialization_size() {
+        // Malformed serialized data indicating a sequence of length u64::MAX.
         let ser = vec![253, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 1, 1, 1, 1, 1, 1, 1, 1];
 
         let options = DefaultOptions::new()


### PR DESCRIPTION
This changes the sequence deserialization logic to not blindly use the size_hint when calling AVec::with_capacity, as it could be malicious or malformed. Instead, we use the same behavior as std::Vec under deserialization, which is to allocate an initial capacity of up to 1MB.

Without this change, the newly added test panics when it tries to call AVec::with_capacity with u64::MAX.