### PR TITLE
Remove dependency on `equator` to speed up compile times

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ license = "MIT"
 keywords = ["vec", "allocation", "box", "slice", "alignment"]
 
 [dependencies]
-equator = "0.4.1"
 serde = { version = "1.0", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@ use core::{
     ops::{Deref, DerefMut},
     ptr::{null_mut, NonNull},
 };
-use equator::assert;
 use raw::ARawVec;
 
 mod raw;
@@ -1060,7 +1059,6 @@ mod tests {
     use super::*;
     use alloc::vec;
     use core::iter::repeat;
-    use equator::assert;
 
     #[test]
     fn new() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1395,7 +1395,7 @@ mod serde_tests {
     #[test]
     fn can_limit_deserialization_size() {
         // Malformed serialized data indicating a sequence of length u64::MAX.
-        let ser = vec![
+        let ser = alloc::vec![
             253, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 1, 1, 1, 1, 1, 1, 1, 1,
         ];
 


### PR DESCRIPTION
I'm cleaning up some compile times on my transitive dependencies, and I noticed that this crate depends on `equator`, which in turn relies on `syn` and `quote` and all the usual proc-macro tooling. This is pretty heavyweight stuff! I also noticed that `aligned-vec` doesn't use any of the special functionality in `equator`, so I removed the dependency. This speeds up compile and check times appreciably:

before:
```
~/p/aligned-vec ((6af6c18c…)|✔) $ cargo clean -q && time cargo b -r
    Blocking waiting for file lock on package cache
    Updating crates.io index
    Blocking waiting for file lock on package cache
    Blocking waiting for file lock on package cache
    Blocking waiting for file lock on package cache
   Compiling proc-macro2 v1.0.95
   Compiling unicode-ident v1.0.18
   Compiling quote v1.0.40
   Compiling syn v2.0.101
   Compiling equator-macro v0.4.2
   Compiling equator v0.4.2
   Compiling aligned-vec v0.6.4 (/home/cwramsey/projects/aligned-vec)
    Finished `release` profile [optimized] target(s) in 3.80s

________________________________________________________
Executed in    3.86 secs    fish           external
   usr time    4.42 secs  660.00 micros    4.42 secs
   sys time    0.74 secs  217.00 micros    0.74 secs
```

after:
```
~/p/aligned-vec (main|✔) $ cargo clean -q && time cargo b -r
   Compiling aligned-vec v0.6.4 (/home/cwramsey/projects/aligned-vec)
    Finished `release` profile [optimized] target(s) in 0.22s

________________________________________________________
Executed in  296.39 millis    fish           external
   usr time  203.09 millis    0.00 micros  203.09 millis
   sys time   93.87 millis  707.00 micros   93.16 millis
```