### PR TITLE
Update equator dependency from 0.4 to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 keywords = ["vec", "allocation", "box", "slice", "alignment"]
 
 [dependencies]
-equator = "0.4.1"
+equator = "0.6.0"
 serde = { version = "1.0", optional = true, default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
It doesn’t *look* like any source-code changes should be required, and `cargo test` still passes.