### PR TITLE
Fix overly large allocations not failing on 64 bit platforms

### DIFF
--- a/src/raw.rs
+++ b/src/raw.rs
@@ -398,7 +398,7 @@ unsafe fn try_grow_unchecked(
 
 #[inline]
 unsafe fn is_valid_alloc(alloc_size: usize, align: usize) -> bool {
-	::std::hint::assert_unchecked(align.is_power_of_two());
+	debug_assert!(align.is_power_of_two());
 	// "size, when rounded up to the nearest multiple of align, must not overflow isize"
 	let max = (isize::MAX as usize) - (align - 1);
 	alloc_size <= max


### PR DESCRIPTION
The unsafe precondition of `Layout` must not be ignored even on 64 bit platforms. Minimal test to reproduce UB under miri:

```rust
#[test]
#[should_panic]
fn large_alloc() {
    let mut vec = AVec::<u8>::new(1);
    vec.reserve((isize::MAX as usize) + 1);
}
```

```
unsafe precondition(s) violated: Layout::from_size_align_unchecked requires that align is a power of 2 and the rounded-up allocation size does not exceed isize::MAX

This indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
note: in Miri, you may have to set `MIRIFLAGS=-Zmiri-env-forward=RUST_BACKTRACE` for the environment variable to have an effect
thread caused non-unwinding panic. aborting.
error: abnormal termination: the program aborted execution
   --> /nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:856:9
    |
856 |         crate::process::abort();
    |         ^^^^^^^^^^^^^^^^^^^^^^^ abnormal termination occurred here
    |
    = note: BACKTRACE on thread `large_alloc`:
    = note: inside `std::panicking::panic_with_hook` at /nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:856:9: 856:32
    = note: inside closure at /nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:700:13: 705:14
    = note: inside `std::sys::backtrace::__rust_end_short_backtrace::<{closure@std::panicking::panic_handler::{closure#0}}, !>` at /nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/backtrace.rs:174:18: 174:21
    = note: inside `std::panicking::panic_handler` at /nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:698:5: 714:7
    = note: inside `aligned_vec::raw::with_capacity_unchecked` at /index.crates.io-1949cf8c6b5b557f/aligned-vec-0.6.4/src/raw.rs:321:18: 321:70
    = note: inside `aligned_vec::raw::ARawVec::<u8, aligned_vec::ConstAlign<128>>::with_capacity_unchecked` at /index.crates.io-1949cf8c6b5b557f/aligned-vec-0.6.4/src/raw.rs:61:50: 65:18
    = note: inside `aligned_vec::raw::ARawVec::<u8, aligned_vec::ConstAlign<128>>::grow_amortized` at /index.crates.io-1949cf8c6b5b557f/aligned-vec-0.6.4/src/raw.rs:109:21: 112:14
    = note: inside `aligned_vec::AVec::<u8, aligned_vec::ConstAlign<128>>::reserve` at /index.crates.io-1949cf8c6b5b557f/aligned-vec-0.6.4/src/lib.rs:430:22: 430:67
```

The rewritten `is_valid_alloc` is now marked unsafe due to assuming that the passed alignment is indeed a power of two. I've checked on godbolt that the produced assembly is minimal:

```rust
example::is_valid_alloc:
 movabs $0x8000000000000000,%rax
 sub    %rsi,%rax
 cmp    %rax,%rdi
 setbe  %al
 ret
```